### PR TITLE
changes RestClient syntax so that we can add a timeout

### DIFF
--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -87,7 +87,12 @@ class TaxSvc
   end
 
   def response(uri, request_hash)
-    RestClient.post(service_url + uri, JSON.generate(request_hash), authorization: credential, content_type: 'application/json') do |response, request, result|
+    RestClient::Request.execute(method: :post,
+                                timeout: 5,
+                                url: service_url + uri,
+                                payload:  JSON.generate(request_hash),
+                                headers: { authorization: credential,
+                                          content_type: 'application/json'})  do |response, request, result|
       response
     end
   end


### PR DESCRIPTION
I haven't figured out how to handle this on the application-side but this should allow us to build fallback scenarios for our apps when Avalara tax service is down.

see http://developer.avalara.com/api-docs/designing-your-integration/errors-and-outages