### PR TITLE
Country error fix

### DIFF
--- a/app/models/spree_avatax_certified/address.rb
+++ b/app/models/spree_avatax_certified/address.rb
@@ -78,7 +78,7 @@ module SpreeAvataxCertified
     end
 
     def country_enabled?
-      enabled_countries.any? { |c| @ship_address.country.try(:name) == c }
+      enabled_countries.any? { |c| @ship_address.try(:country).try(:name) == c }
     end
 
     private

--- a/lib/spree_avatax_certified/seeder.rb
+++ b/lib/spree_avatax_certified/seeder.rb
@@ -17,17 +17,24 @@ module SpreeAvataxCertified
       def create_tax
         clothing = Spree::TaxCategory.find_or_create_by(name: 'Clothing')
         clothing.update_attributes(tax_code: 'P0000000')
+        tax_zone = Spree::Zone.find_or_create_by(name: 'North America')
+        tax_calculator = Spree::Calculator::AvalaraTransactionCalculator.create!
+        sales_tax = Spree::TaxRate.find_or_create_by(name: 'Tax') do |tax_rate|
+          # default values for the create
+          tax_rate.amount = BigDecimal.new('0')
+          tax_rate.calculator = tax_calculator
+          tax_rate.tax_category = clothing
+        end
+        sales_tax.update!(tax_category: clothing, name: 'Tax', amount: BigDecimal.new('0'), zone: tax_zone, show_rate_in_label: false, calculator: tax_calculator)
 
         shipping = Spree::TaxCategory.find_or_create_by(name: 'Shipping', tax_code: 'FR000000')
-
-        sales_tax = Spree::TaxRate.find_or_create_by(name: 'North America')
-        sales_tax.update_attributes(tax_category: clothing, name: 'Tax', amount: BigDecimal.new('0'), zone: Spree::Zone.find_by_name('North America'), show_rate_in_label: false)
-        sales_tax.calculator = Spree::Calculator::AvalaraTransactionCalculator.create!
-        sales_tax.save!
-
-        shipping_tax = Spree::TaxRate.create(name: 'Shipping Tax', tax_category: shipping, amount: BigDecimal.new('0'), zone: Spree::Zone.find_by_name('North America'), show_rate_in_label: false)
-        shipping_tax.calculator = Spree::Calculator::AvalaraTransactionCalculator.create!
-        shipping_tax.save!
+        shipping_tax = Spree::TaxRate.find_or_create_by(name: 'Shipping Tax') do |shipping_tax|
+          shipping_tax.tax_category = shipping
+          shipping_tax.amount = BigDecimal.new('0')
+          shipping_tax.zone = tax_zone
+          shipping_tax.show_rate_in_label = false
+        end
+        shipping_tax.update!(tax_category: shipping, amount: BigDecimal.new('0'), zone: Spree::Zone.find_by_name('North America'), show_rate_in_label: false, calculator: Spree::Calculator::AvalaraTransactionCalculator.create!)
       end
 
       def create_use_codes

--- a/spec/models/spree_avatax_certified/address_spec.rb
+++ b/spec/models/spree_avatax_certified/address_spec.rb
@@ -73,5 +73,13 @@ describe SpreeAvataxCertified::Address, :type => :model do
     it 'returns true if the current country is enabled' do
       expect(address_lines.country_enabled?).to be_truthy
     end
+    context "with no ship_address connected to the order" do
+      before do
+        order.ship_address = nil
+      end
+      it 'returns false if there is no @ship_address' do
+        expect(address_lines.country_enabled?).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
SpreeAvataxCertified::Address#country_enabled? was throwing an error when there was no ship_address connected to the order yet.

I also added a test to the method to be sure it doesn't throw an error still.